### PR TITLE
Run code coverage with `log` both enabled and disabled 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,6 +63,4 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: actions-rs/tarpaulin@v0.1
-      with:
-        args: --all-features
     - uses: codecov/codecov-action@v1

--- a/.tarpaulin.toml
+++ b/.tarpaulin.toml
@@ -1,0 +1,4 @@
+[feature_log_coverage]
+features = "log"
+
+[feature_no_log_coverage]


### PR DESCRIPTION
Fixes #27, although there are still a few missed lines due to the log statements being no-ops when `log` is disabled. Not sure if there is a way to fix that, since they compile into nothing.