### PR TITLE
Enable ignoring tests in `tarpaulin`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,4 +63,6 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: actions-rs/tarpaulin@v0.1
+      with:
+        args: --ignore-tests --all-features
     - uses: codecov/codecov-action@v1

--- a/.tarpaulin.toml
+++ b/.tarpaulin.toml
@@ -1,4 +1,0 @@
-[feature_log_coverage]
-features = "log"
-
-[feature_no_log_coverage]


### PR DESCRIPTION
Fixes #30. Moving forward, code coverage will be done using all features. I don't anticipate this will be a problem, since features are additive anyway.